### PR TITLE
Fix black "No recent matches." text

### DIFF
--- a/KeywordTracker/index.js
+++ b/KeywordTracker/index.js
@@ -436,7 +436,7 @@ module.exports = (Plugin, Library) => {
         };
         if (sortedMatches.length === 0) {
           root.textContent = 'No recent matches.';
-          root.setAttribute('style', 'line-height: 90px; text-align: center;');
+          root.setAttribute('style', 'line-height: 90px; text-align: center;  color: var(--text-normal);');
         } else {
           for(let msg of sortedMatches) {
             root.appendChild(matchEntry(msg));


### PR DESCRIPTION
This fixes the "No recent matches." being black. It is now the normal text colour.

Before
![image](https://github.com/sarahkittyy/KeywordTrackerSource/assets/48070995/3b290e9a-8d15-4f90-8c04-3e85ffebe725)

After
![image](https://github.com/sarahkittyy/KeywordTrackerSource/assets/48070995/831b36f1-5c14-44b2-85cd-49b93ba705b0)
